### PR TITLE
Allow for passing country model in place of ID

### DIFF
--- a/models/State.php
+++ b/models/State.php
@@ -50,12 +50,30 @@ class State extends Model
      */
     protected static $nameList = [];
 
-    public static function getNameList($countryId)
+    /**
+     * Get list of State names for dropdowns
+     * @param  Country|int  $country    Country model or ID to list the States from
+     * @return array
+     */
+    public static function getNameList($country)
     {
-        if (isset(self::$nameList[$countryId]))
-            return self::$nameList[$countryId];
+        $country instanceof Country
+        ? self::setNameList($countryId = $country->id, $country->states())
+        : self::setNameList($countryId = $country, self::whereCountryId($country));
 
-        return self::$nameList[$countryId] = self::whereCountryId($countryId)->lists('name', 'id');
+        return self::$nameList[$countryId];
+    }
+
+    /**
+     * Add the State list to cache for a given Country
+     * @param int             $countryId
+     * @param Builder|HasMany $stateModel
+     */
+    protected static function setNameList($countryId, $stateModel)
+    {
+        if (!isset(self::$nameList[$countryId])) {
+            self::$nameList[$countryId] = $stateModel->lists('name', 'id');
+        }
     }
 
     public static function formSelect($name, $countryId = null, $selectedValue = null, $options = [])
@@ -67,5 +85,4 @@ class State extends Model
     {
         return static::find(Settings::get('default_state', 1));
     }
-
 }


### PR DESCRIPTION
In most cases, where someone's calling `State::getNameList()`, they probably already have a `hasMany` countries relation setup on their model. With this commit, they will be able to pass the model into the method directly, instead of having to pass `$this->country->id`

Example:
```php
<?php namespace Acme\Foo\Models

use RainLab\Location\Models\State;

class Thing extends Model
{
    public $belongsTo = [
        'country' => ['RainLab\Location\Models\Country'],
        'state'   => ['RainLab\Location\Models\State'],
    ];

    public function getStateOptions()
    {
        // Passing the ID (the old way, still works)
        return State::getNameList(42);

        // Passing the ID of related Country (works sometimes, see below)
        return State::getNameList($this->country->id);

        // Passing the model (new way, easier, identical result)
        return State::getNameList($this->country);
    }
}
```

Currently the pay plugin attempts to pass `$this->country_id` but that's actually `NULL`.

With fields generally named by the respective relation (e.g. using `country` as opposed to `country_id`), we already have an instance of the Country model. It makes sense to take advantage of that fact, which is exactly what this PR does.

### Caveats when using `$this->country->id`
When first viewing Create page, it throws a `Trying to get property of non-object` error. As soon as a country is selected from the dropdown it fixes itself.

Passing model with `$this->country` works all the time, even prior to setting the country. With that in mind, best option for users would be a hard-coded integer or the related country model.