### PR TITLE
Make LocationModel compatible with $guarded fields

### DIFF
--- a/behaviors/LocationModel.php
+++ b/behaviors/LocationModel.php
@@ -28,14 +28,16 @@ class LocationModel extends ModelBehavior
     {
         parent::__construct($model);
 
-        $model->addFillable([
-            'country',
-            'country_id',
-            'country_code',
-            'state',
-            'state_id',
-            'state_code'
-        ]);
+        if (!empty($model->getFillable())) {
+            $model->addFillable([
+                'country',
+                'country_id',
+                'country_code',
+                'state',
+                'state_id',
+                'state_code'
+            ]);
+        }
 
         $model->belongsTo['country'] = ['RainLab\Location\Models\Country'];
         $model->belongsTo['state']   = ['RainLab\Location\Models\State'];

--- a/behaviors/LocationModel.php
+++ b/behaviors/LocationModel.php
@@ -28,7 +28,9 @@ class LocationModel extends ModelBehavior
     {
         parent::__construct($model);
 
-        if (!empty($model->getFillable())) {
+        $guarded = $model->getGuarded();
+
+        if (count($guarded) === 1 && $guarded[0] === '*') {
             $model->addFillable([
                 'country',
                 'country_id',


### PR DESCRIPTION
Closes #52.

Checks if the implementing model has defined `$fillable` properties before adding location properties as fillable. This allows the developer to choose either the whitelist approach (eg. defining `$fillable` fields), or the blacklist approach (eg. defining `$guarded` fields) for mass-assignment protection.