### PR TITLE
Add UK and Sweden city support to addressfinder

### DIFF
--- a/formwidgets/addressfinder/assets/js/location-autocomplete.js
+++ b/formwidgets/addressfinder/assets/js/location-autocomplete.js
@@ -97,7 +97,7 @@
             },
             'short': {
                 inputStreet: ['street_number', 'route'],
-                inputCity: 'locality',
+                inputCity: ['locality', 'postal_town'],
                 inputZip: 'postal_code',
                 inputState: 'administrative_area_level_1',
                 inputCountry: 'country'


### PR DESCRIPTION
Added postal_town to the value map so that UK and Swedish addresses correctly fill the city component since that is their correct field from Google's response (ref: https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform )