### PR TITLE
Fix Duplicate Classname

### DIFF
--- a/updates/add_country_callingcode.php
+++ b/updates/add_country_callingcode.php
@@ -4,7 +4,7 @@ use Schema;
 use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
-class AddCountryPinnedFlag extends Migration
+class AddCountryCallingCode extends Migration
 {
     public function up()
     {


### PR DESCRIPTION
Unbale to install plugin because of duplicate Classname in migration files