### PR TITLE
Fix country-long mapping

### DIFF
--- a/formwidgets/addressfinder/assets/js/location-autocomplete.js
+++ b/formwidgets/addressfinder/assets/js/location-autocomplete.js
@@ -130,7 +130,7 @@
                 google = [google]
 
             $.each(google, function(index, _google) {
-                value.push(self.getValueFromAddressObject(place, _google))
+                value.push(self.getValueFromAddressObject(place, _google, resultType))
             })
 
             return value.join(' ')


### PR DESCRIPTION
The ``country-long`` mapping currently doesn't work, since the requested ``resultType`` was never passed along to the ``getValueFromAddressObject`` function. So it always returned the short name.

This PR fixes the issue.