### PR TITLE
Add option to reverse street and number

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Available options:
 
 You can restrict the address lookup to certain countries by defining the `countryRestriction` option. The option accepts a comma separated list of ISO 3166-1 ALPHA-2 compatible country codes (see: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
 
+By default the `street` mapper places the house number before the street name. However in some countries the number is commonly placed after the street name. You can reverse the order by using the `reverseStreetNumber: true` option.
+
 Usage:
 
     # ===================================
@@ -147,11 +149,13 @@ Usage:
             label: Address
             type: addressfinder
             countryRestriction: 'us,ch'
+            reverseStreetNumber: false
             fieldMap:
                 latitude: latitude
                 longitude: longitude
                 city: city
                 zip: zip
+                street: street
                 country: country_code
                 state: state_code
                 vicinity: vicinity
@@ -160,6 +164,8 @@ Usage:
             label: City
         zip:
             label: Zip
+        street:
+            label: Street
         country_code:
             label: Country
         state_code:

--- a/formwidgets/AddressFinder.php
+++ b/formwidgets/AddressFinder.php
@@ -41,12 +41,18 @@ class AddressFinder extends FormWidgetBase
     protected $countryRestriction;
 
     /**
+     * @var string reverseStreetNumber
+     */
+    protected $reverseStreetNumber;
+
+    /**
      * {@inheritDoc}
      */
     public function init()
     {
         $this->fieldMap = $this->getConfig('fieldMap', []);
         $this->countryRestriction = $this->getConfig('countryRestriction', '');
+        $this->reverseStreetNumber = $this->getConfig('reverseStreetNumber', false);
     }
 
     /**
@@ -94,6 +100,14 @@ class AddressFinder extends FormWidgetBase
     public function getCountryRestriction()
     {
         return $this->countryRestriction;
+    }
+
+    /**
+     * getStreetReverseValue
+     */
+    public function getReverseStreetNumber()
+    {
+        return $this->reverseStreetNumber ? 1 : 0;
     }
 
     /**

--- a/formwidgets/addressfinder/assets/js/location-autocomplete.js
+++ b/formwidgets/addressfinder/assets/js/location-autocomplete.js
@@ -94,13 +94,19 @@
     }
 
     LocationAutocomplete.prototype.getValueMap = function() {
+        var streetValueMap = ['street_number', 'route']
+
+        if(this.$el.data('reverse-street-number')) {
+            streetValueMap = ['route', 'street_number']
+        }
+
         return {
             'geometry': {
                 inputLatitude: 'lat',
                 inputLongitude: 'lng'
             },
             'short': {
-                inputStreet: ['street_number', 'route'],
+                inputStreet: streetValueMap,
                 inputCity: ['locality', 'postal_town'],
                 inputCounty: 'administrative_area_level_2',
                 inputState: 'administrative_area_level_1',

--- a/formwidgets/addressfinder/partials/_addressfinder.htm
+++ b/formwidgets/addressfinder/partials/_addressfinder.htm
@@ -12,6 +12,7 @@
             data-control="location-autocomplete"
             <?= $field->getAttributes() ?>
             data-country-restriction="<?= $this->getCountryRestriction() ?>"
+            data-reverse-street-number="<?= $this->getReverseStreetNumber() ?>"
             <?= $this->getFieldMapAttributes() ?>
             />
     </div>


### PR DESCRIPTION
By default the `street` mapper places the house number before the street name. However in some countries (i.e. most European countries) the number is commonly placed after the street name.

I added a new option `reverseStreetNumber: true` to enable this behavior.

If reverseStreetNumber == false (or missing):

![image](https://user-images.githubusercontent.com/6329543/179262008-6082611d-a886-4bed-9f6d-c353209c4c38.png)

If reverseStreetNumber == true:

![image](https://user-images.githubusercontent.com/6329543/179261835-8ea8dd46-7f03-420b-b9c3-b93f20d81d35.png)
