### PR TITLE
Fix invalid syntax in seeder

### DIFF
--- a/updates/seed_at_states.php
+++ b/updates/seed_at_states.php
@@ -13,7 +13,7 @@ class SeedAtStates extends Seeder
             return;
         }
 
-        $at->states()->createMany(
+        $at->states()->createMany([
             ['code' => 'WI', 'name' => 'Wien'],
             ['code' => 'NI', 'name' => 'Niederösterreich'],
             ['code' => 'OB', 'name' => 'Oberösterreich'],


### PR DESCRIPTION
Fixes the following issue when migrating the plugin:

![image](https://user-images.githubusercontent.com/6329543/179358224-0c04c05c-fb7f-4891-bcd3-b5d3c1b48105.png)
