### PR TITLE
Resolving #102

### DIFF
--- a/models/Country.php
+++ b/models/Country.php
@@ -96,12 +96,13 @@ class Country extends Model
     public static function getFromIp($ipAddress)
     {
         try {
-            $body = (string) Http::get('http://ip2c.org/?ip='.$ipAddress);
-
-            if (substr($body, 0, 1) === '1') {
-                $code = explode(';', $body)[1];
-                return static::where('code', $code)->first();
-            }
+            
+            $body = Http::get('https://api.country.is/'.$ipAddress);
+            
+			if($body->code == 200) {
+	            $json = json_decode($body->body);
+	            return static::where('code', strtolower($json->country))->first();
+	        }
         }
         catch (Exception $e) {}
     }

--- a/models/Country.php
+++ b/models/Country.php
@@ -95,15 +95,15 @@ class Country extends Model
      */
     public static function getFromIp($ipAddress)
     {
-        try {
-            
-            $body = Http::get('https://api.country.is/'.$ipAddress);
-            
+		try {
+
+			$body = Http::get('https://api.country.is/'.$ipAddress);
+
 			if($body->code == 200) {
-	            $json = json_decode($body->body);
-	            return static::where('code', strtolower($json->country))->first();
-	        }
-        }
-        catch (Exception $e) {}
+				$json = json_decode($body->body);
+				return static::where('code', strtolower($json->country))->first();
+			}
+		}
+		catch (Exception $e) {}
     }
 }


### PR DESCRIPTION
Updated service (ip2c.org)
background reasons. ip2c.org was listed in blocked origins in multiple services like uBlock, PiHole, etc. which means, that will fail resolving correct values. Second tought was, that is used an unsecure `http://` request